### PR TITLE
Feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MANDIR = $(PREFIX)/share/man/man1
 
 # Flags
 LDFLAGS = $(shell pkg-config --libs ncurses)
-CFLAGS = -march=native -mtune=native -O3 -pipe -s -std=c99 -pedantic $(shell pkg-config --cflags ncurses) -Wall # -Wextra -Werror
+CFLAGS = -O3 -pipe -s -std=c99 -pedantic -Wall $(shell pkg-config --cflags ncurses)
 
 SRC = ccc.c util.c file.c $(CONF)
 

--- a/README.md
+++ b/README.md
@@ -8,36 +8,73 @@ The fact that it is written in C makes it more versatile and rapid, enabling us 
 
 Consider this project incomplete and WIP!
 
-| Feature                        | Ported | Dropped | Added |
-|--------------------------------|:------:|:-------:|:-----:|
-| Standard movement              |   X    |         |       |
-| Advanced movement (jumps)      |   X    |         |       |
-| Searching                      |        |         |       |
-| File preview                   |        |         |   X   |
-| Sorting                        |        |         |       |
-| Marking and marking operations |        |         |       |
-| Other operations on files      |        |         |       |
-| File details                   |   X    |         |       |
-| Image previews                 |        |         |       |
-| Help                           |        |         |       |
-| History                        |        |         |       |
-| Bookmarks                      |        |         |       |
-| Bulk rename                    |        |         |       |
-| Workspaces                     |        |         |       |
+| Feature of fff                 | Ported | Dropped |
+|--------------------------------|:------:|:-------:|
+| Standard movement              |   X    |         |
+| Advanced movement (jumps)      |   X    |         |
+| File details                   |   X    |         |
+| Searching for files            |        |         |
+| Sorting                        |        |         |
+| Marking and marking operations |        |         |
+| Other operations on files      |        |         |
+| Image previews                 |        |         |
+| Help                           |        |         |
+| History                        |        |         |
+| Bookmarks                      |        |         |
+| Bulk rename                    |        |         |
+
+#### Features added that are not in [fff](https://github.com/piotr-marendowski/fff):
+
+- File preview (without highlighting)
+
+## Installation
 
 ### Dependencies
 
 - gcc
+- ncurses
 - make
 - pkg-config
-- ncurses
 
 ### Building
 
 You will need to run these with elevated privilages.
 
-```sh
+```
 $ git clone https://github.com/piotr-marendowski/ccc
 $ make 
 $ sudo make install
 ```
+
+## Usage
+
+```
+j: scroll down
+k: scroll up
+h: go to parent dir
+l: go to child dir
+
+down:  scroll down
+up:    scroll up
+left:  go to parent dir
+right: go to child dir
+
+enter: go to child dir/open file
+backspace: go to parent dir
+
+g: go to top
+G: go to bottom
+
+t: go to trash
+~: go to home
+z: refresh current dir
+
+space: mark file
+a: mark all files in directory
+
+q: exit
+```
+
+## License
+
+This project has GNU GPL v.3 license.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ The fact that it is written in C makes it more versatile and rapid, enabling us 
 
 ## Features
 
-- Vim-like key binding
-- File Preview
-
 Consider this project incomplete and WIP!
 
 | Feature                        | Ported | Dropped | Added |

--- a/ccc.1
+++ b/ccc.1
@@ -1,0 +1,47 @@
+.
+.TH CCC "1" "March 2024" "ccc" "User Commands"
+.SH NAME
+ccc \- Fast TUI file manager written in C, using ncurses.
+.SH SYNOPSIS
+.B ccc
+.SH DESCRIPTION
+ccc is a rewrite of fff file manager in C aiming for usefulness and speed. The fact that it is written in C makes it more versatile and rapid, enabling us to add features that were previously ruled out due to time complexity. You may call it a soft fork.
+.PP
+.SH "Usage"
+.
+.nf
+
+j: scroll down
+k: scroll up
+h: go to parent dir
+l: go to child dir
+
+down:  scroll down
+up:    scroll up
+left:  go to parent dir
+right: go to child dir
+
+enter: go to child dir/open file
+backspace: go to parent dir
+
+g: go to top
+G: go to bottom
+
+t: go to trash
+~: go to home
+z: refresh current dir
+
+space: mark file
+a: mark all files in directory
+
+q: exit
+.
+.fi
+.
+.SH "Customization"
+.
+.nf
+
+Various settings can be changed in config.h file located in the program's directory.
+.
+.fi

--- a/ccc.c
+++ b/ccc.c
@@ -747,7 +747,7 @@ void draw_border_title(WINDOW *window, bool active, int id)
     /* check if the window is directory of preview */
     int width = half_width;
     if (id == 0) {          /* left */
-         width += WINDOW_OFFSET;    
+        width += WINDOW_OFFSET;    
     } else if (id == 1) {   /* right */
         width -= WINDOW_OFFSET;
     }

--- a/ccc.c
+++ b/ccc.c
@@ -202,7 +202,7 @@ int main(int argc, char** argv)
                 }
                 break;
 
-            /* go to $HOME */
+            /* '~' go to $HOME */
             case TILDE:;
                 char *home = getenv("HOME");
                 if (home == NULL) {
@@ -385,7 +385,7 @@ int get_directory_size(const char *fpath, const struct stat *sb, int typeflag, s
 /*
  * Get file's last modified time, size, type
  * Add that file into list
- * ftype: 0 = normal file, 1 = marked
+ * ftype: normal file = 0, marked = 1
  */
 long add_file_stat(char *filepath, int ftype)
 {
@@ -427,6 +427,8 @@ long add_file_stat(char *filepath, int ftype)
     /* if file is to be marked */
     if (ftype == 1) {
         long index = add_marked(filepath, type);
+        /* free type and return without allocating more stuff */
+        free(type);
         if (index != -1) {
             return index;   /* just marked */
         } else {
@@ -454,23 +456,22 @@ long add_file_stat(char *filepath, int ftype)
     /* max 25 chars due to long, space, suffix and null */
     char *size = memalloc(25 * sizeof(char));
     int unit = 0;
-    const char* units[] = {"  B", "KiB", "MiB", "GiB", "TiB", "PiB"};
+    const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB"};
     while (bytes > 1024) {
         bytes /= 1024;
         unit++;
     }
-    /* 4 sig fig, limiting characters to have better format  */
-    sprintf(size, "%-6.4g %-3s", bytes, units[unit]);
+    /* display sizes */
+    sprintf(size, "%.3g%s", bytes, units[unit]);
 
     char *total_stat = memalloc(45 * sizeof(char));
-    snprintf(total_stat, 45, "%-18s %-10s", time, size);
+    snprintf(total_stat, 45, "%-18s %-8s", time, size);
     total_stat[strlen(total_stat)] = '\0';
+
+    long index = add_file(filepath, total_stat, type, color);
 
     free(time);
     free(size);
-    
-    long index = add_file(filepath, total_stat, type, color);
-
     free(total_stat);
     free(type);
     return index;
@@ -636,7 +637,7 @@ void edit_file()
 }
 
 /*
- * Print line to panel
+ * Print line to the panel
  */
 void wpprintw(const char *line)
 {

--- a/ccc.c
+++ b/ccc.c
@@ -236,16 +236,15 @@ int main(int argc, char** argv)
                 break;
 
             /* mark one file */
-            case SPACE:;
+            case SPACE:
                 add_file_stat(get_filepath(current_selection), 1);
                 highlight_current_line();
                 break;
 
             /* mark all files in directory */
-            case 'a':;
-                int save_current_sel = current_selection;
-                populate_files(cwd, 1);
-                change_dir(cwd, save_current_sel);      /* reload current dir */
+            case 'a':
+                populate_files(cwd, 2);
+                change_dir(cwd, current_selection); /* reload current dir */
                 break;
 
             /* mark actions: */
@@ -368,7 +367,7 @@ int mkdir_p(const char *destdir)
 
 /*
  * Read the provided directory and add all files in directory to linked list
- * ftype: normal files = 0, marked = 1
+ * ftype: normal files = 0, marked = 1, marking ALL = 2
  * ep->d_name -> filename
  */
 void populate_files(const char *path, int ftype)
@@ -417,7 +416,7 @@ int get_directory_size(const char *fpath, const struct stat *sb, int typeflag, s
 /*
  * Get file's last modified time, size, type
  * Add that file into list
- * ftype: normal file = 0, marked = 1
+ * ftype: normal file = 0, normal marked = 1, marking ALL = 2
  */
 long add_file_stat(char *filepath, int ftype)
 {
@@ -457,8 +456,10 @@ long add_file_stat(char *filepath, int ftype)
     }
 
     /* if file is to be marked */
-    if (ftype == 1) {
-        long index = add_marked(filepath, type);
+    if (ftype == 1 || ftype == 2) {
+        /* force if user is marking all files */
+        bool force = ftype == 2 ? true : false;
+        long index = add_marked(filepath, type, force);
         /* free type and return without allocating more stuff */
         free(type);
         if (index != -1) {

--- a/ccc.c
+++ b/ccc.c
@@ -495,7 +495,7 @@ long add_file_stat(char *filepath, int ftype)
     /* max 25 chars due to long, space, suffix and null */
     char *size = memalloc(25 * sizeof(char));
     int unit = 0;
-    const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB"};
+    const char* units[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
     while (bytes > 1024) {
         bytes /= 1024;
         unit++;

--- a/config.h
+++ b/config.h
@@ -2,7 +2,7 @@
 #define PH 1            /* panel height */
 #define JUMP_NUM 14     /* how long ctrl + u/d jump are */
 
-/* Calculate directories' sizes upon entering? */
+/* Calculate directories' sizes RECURSIVELY upon entering? */
 #define DIRS_SIZE false
 
 /* Default text editor */

--- a/config.h
+++ b/config.h
@@ -5,6 +5,23 @@
 /* Calculate directories' sizes RECURSIVELY upon entering? */
 #define DIRS_SIZE false
 
+#define DRAW_BORDERS true   /* Draw borders around windows? */
+#define DRAW_PREVIEW true   /* Draw file preview? */
+
+/* set width offset for windows:
++-------------%-------------+
+|             %             |
+|    files    %   preview   |
+|             %             |
++=============%=============+
+set where the % line between them resides
+
+In COLS:
+0 will make them equal (at the center),
+15 will make files bigger
+-15 will make preview bigger */
+#define WINDOW_OFFSET 0
+
 /* Default text editor */
 #define EDITOR "nvim"
 

--- a/config.h
+++ b/config.h
@@ -1,3 +1,14 @@
+/* Settings */
+#define PH 1            /* panel height */
+#define JUMP_NUM 14     /* how long ctrl + u/d jump are */
+
+/* Calculate directories' sizes upon entering? */
+#define DIRS_SIZE false
+
+/* Default text editor */
+#define EDITOR "nvim"
+
+/* Keybindings */
 #define CTRLD 0x04
 #define ENTER 0xA
 #define CTRLU 0x15
@@ -9,9 +20,3 @@
 #define LEFT 0x104
 #define RIGHT 0x105
 #define BACKSPACE 0x107
-#define PH 1            /* panel height */
-#define JUMP_NUM 14     /* how long ctrl + u/d jump are */
-#define BLOCK_SIZE true
-#define DISK_USAGE false
-
-static const char *editor = "nvim"; /* default text editor */

--- a/file.c
+++ b/file.c
@@ -265,3 +265,9 @@ char *get_line(long index)
         return NULL;
     }
 }
+
+
+/*
+ * Get file's type and color
+ */
+char *get_type(__mode_t st_mode);

--- a/file.c
+++ b/file.c
@@ -265,9 +265,3 @@ char *get_line(long index)
         return NULL;
     }
 }
-
-
-/*
- * Get file's type and color
- */
-char *get_type(__mode_t st_mode);

--- a/file.c
+++ b/file.c
@@ -131,7 +131,10 @@ void remove_marked(file *marked_file)
     }
 }
 
-long add_marked(char *filepath, char *type)
+/*
+ * force will not remove duplicate marked files, instead it just skip adding
+ */
+long add_marked(char *filepath, char *type, bool force)
 {
     file *current = marked;
     file *new_file = memalloc(sizeof(file));
@@ -153,17 +156,25 @@ long add_marked(char *filepath, char *type)
     long index = 1;
     while (current->next != NULL) {
         if (strcmp(current->path, new_file->path) == 0) {
-            remove_marked(current);
-            free_file(new_file);
-            return -1;
+            if (force) {
+                return index;
+            } else {
+                remove_marked(current);
+                free_file(new_file);
+                return -1;
+            }
         }
         current = current->next;
         index++;
     }
     if (strcmp(current->path, new_file->path) == 0){
-        remove_marked(current);
-        free_file(new_file);
-        return -1;
+        if (force) {
+            return 0;
+        } else {
+            remove_marked(current);
+            free_file(new_file);
+            return -1;
+        }
     }
     current->next = new_file;
     return index;

--- a/file.h
+++ b/file.h
@@ -16,7 +16,7 @@ void clear_files();
 void clear_marked();
 long add_file(char *filepath, char *stats, char *type, int color);
 void remove_marked(file *marked_file);
-long add_marked(char *filepath, char *type);
+long add_marked(char *filepath, char *type, bool force);
 file *get_marked(long index);
 bool in_marked(char *path);
 file *get_file(long index);


### PR DESCRIPTION
- use config.h variables to config program, if not fallback to env variables
- change 'show directory size' method to use key 'A'
- mark all by 'a'
- remove WIN_STRUCT as it is not used
- change dir with cursor location (specifically for mark all files)
- add field ftype to populate files to add all marked files to marked ll
- refactor
- better documentation
- add DRAW_PREVIEW option in config.h to show preview or not
- add WINDOW_OFFSET to shift windows to left and right to show more preview/more directory
- add DRAW_BORDERS to draw border or not to show more content
- delete by 'd' - to be implemented
- move by 'm' - to be implemented
- copy by 'c' - to be implemented
- sym link by 's' - to be implemented
- bulk rename by 'b' - to be implemented